### PR TITLE
[sanitizer_symbolizer] Add Symbolizer Markup for linux

### DIFF
--- a/clang/docs/tools/clang-formatted-files.txt
+++ b/clang/docs/tools/clang-formatted-files.txt
@@ -1837,7 +1837,7 @@ compiler-rt/lib/sanitizer_common/sanitizer_stack_store.cpp
 compiler-rt/lib/sanitizer_common/sanitizer_stack_store.h
 compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_fuchsia.h
 compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
-compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_fuchsia.h
+compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
 compiler-rt/lib/sanitizer_common/sanitizer_thread_safety.h
 compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.h
 compiler-rt/lib/sanitizer_common/sanitizer_type_traits.cpp

--- a/compiler-rt/lib/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_common/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SANITIZER_SYMBOLIZER_SOURCES
   sanitizer_stacktrace_printer.cpp
   sanitizer_stacktrace_sparc.cpp
   sanitizer_symbolizer.cpp
+  sanitizer_symbolizer_fuchsia.cpp
   sanitizer_symbolizer_libbacktrace.cpp
   sanitizer_symbolizer_libcdep.cpp
   sanitizer_symbolizer_mac.cpp
@@ -187,10 +188,11 @@ set(SANITIZER_IMPL_HEADERS
   sanitizer_stoptheworld.h
   sanitizer_suppressions.h
   sanitizer_symbolizer.h
-  sanitizer_symbolizer_fuchsia.h
+  sanitizer_symbolizer_markup_constants.h
   sanitizer_symbolizer_internal.h
   sanitizer_symbolizer_libbacktrace.h
   sanitizer_symbolizer_mac.h
+  sanitizer_symbolizer_markup.h
   sanitizer_syscall_generic.inc
   sanitizer_syscall_linux_aarch64.inc
   sanitizer_syscall_linux_arm.inc

--- a/compiler-rt/lib/sanitizer_common/sanitizer_coverage_fuchsia.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_coverage_fuchsia.cpp
@@ -35,7 +35,7 @@
 #include "sanitizer_common.h"
 #include "sanitizer_interface_internal.h"
 #include "sanitizer_internal_defs.h"
-#include "sanitizer_symbolizer_fuchsia.h"
+#include "sanitizer_symbolizer_markup_constants.h"
 
 using namespace __sanitizer;
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -269,3 +269,7 @@ COMMON_FLAG(bool, detect_write_exec, false,
 COMMON_FLAG(bool, test_only_emulate_no_memorymap, false,
             "TEST ONLY fail to read memory mappings to emulate sanitized "
             "\"init\"")
+COMMON_FLAG(
+    bool, enable_symbolizer_markup, false,
+    "Use sanitizer symbolizer markup, "
+    "available only on Linux.")

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -415,9 +415,9 @@
 
 // Enable offline markup symbolizer for Fuchsia.
 #if SANITIZER_FUCHSIA
-#  define SANITIZER_SYMBOLIZER_MARKUP 1
+#  define SANITIZER_SYMBOLIZER_FUCHSIA 1
 #else
-#  define SANITIZER_SYMBOLIZER_MARKUP 0
+#  define SANITIZER_SYMBOLIZER_FUCHSIA 0
 #endif
 
 // Enable ability to support sanitizer initialization that is

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_printer.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_printer.h
@@ -51,6 +51,10 @@ class StackTracePrinter {
   ~StackTracePrinter() {}
 };
 
+// See sanitizer_symbolizer_markup.cpp for the fuhchsia implementation of
+// StackTracePrinter
+#if !SANITIZER_SYMBOLZER_FUCHSIA
+
 class FormattedStackTracePrinter : public StackTracePrinter {
  public:
   // Strip interceptor prefixes from function name.
@@ -109,6 +113,7 @@ class FormattedStackTracePrinter : public StackTracePrinter {
  protected:
   ~FormattedStackTracePrinter() {}
 };
+#endif // !SANITIZER_SYMBOLIZER_FUCHSIA
 
 }  // namespace __sanitizer
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer.cpp
@@ -129,6 +129,12 @@ Symbolizer::Symbolizer(IntrusiveList<SymbolizerTool> tools)
     : module_names_(&mu_), modules_(), modules_fresh_(false), tools_(tools),
       start_hook_(0), end_hook_(0) {}
 
+Symbolizer::Symbolizer(SymbolizerTool *tool)
+    : module_names_(&mu_), modules_(), modules_fresh_(false), tools_(),
+      start_hook_(0), end_hook_(0) {
+    tools_.push_back(tool);
+}
+
 Symbolizer::SymbolizerScope::SymbolizerScope(const Symbolizer *sym)
     : sym_(sym), errno_(errno) {
   if (sym_->start_hook_)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer.h
@@ -154,6 +154,11 @@ class Symbolizer final {
 
   void InvalidateModuleList();
 
+#if !SANITIZER_SYMBOLIZER_FUCHSIA
+  // Returns the list of modules refreshing it if necessary;
+  const ListOfModules &GetRefreshedListOfModules();
+#endif // SANITIZER_SYMBOLIZER_FUCHSIA
+
  private:
   // GetModuleNameAndOffsetForPC has to return a string to the caller.
   // Since the corresponding module might get unloaded later, we should create
@@ -201,6 +206,7 @@ class Symbolizer final {
   IntrusiveList<SymbolizerTool> tools_;
 
   explicit Symbolizer(IntrusiveList<SymbolizerTool> tools);
+  explicit Symbolizer(SymbolizerTool *tool);
 
   static LowLevelAllocator symbolizer_allocator_;
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_fuchsia.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_fuchsia.cpp
@@ -1,0 +1,161 @@
+//===-- sanitizer_symbolizer_fuchsia.cpp
+//-----------------------------------===//
+//
+// Part of the LLVM Proect, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of offline markup symbolizer for fuchsia.
+//
+//===----------------------------------------------------------------------===//
+
+#include "sanitizer_platform.h"
+
+#if SANITIZER_SYMBOLIZER_FUCHSIA
+
+#  include <limits.h>
+#  include <unwind.h>
+
+#  include "sanitizer_stacktrace.h"
+#  include "sanitizer_stacktrace_printer.h"
+#  include "sanitizer_symbolizer.h"
+#  include "sanitizer_symbolizer_markup.h"
+
+namespace __sanitizer {
+
+class FuchsiaStackTracePrinter : public StackTracePrinter {
+ public:
+  const char *StripFunctionName(const char *function) override {
+    if (!function) {
+      return nullptr;
+    }
+
+    return function;
+  }
+
+  void RenderFrame(InternalScopedString *buffer, const char *format,
+                   int frame_no, uptr address, const AddressInfo *info,
+                   bool vs_style, const char *strip_path_prefix = "") override {
+    RenderFrameMarkup(buffer, frame_no, address);
+  }
+
+  bool RenderNeedsSymbolization(const char *format) override { return false; }
+
+  void RenderData(InternalScopedString *buffer, const char *format,
+                  const DataInfo *DI,
+                  const char *strip_path_prefix = "") override {
+    RenderDataMarkup(buffer, DI);
+  }
+
+  // This is not used when emitting sanitizer_markup since the context for
+  // the source location is encoded in the modules and backtraces elements.
+  void RenderSourceLocation(InternalScopedString *, const char *, int, int,
+                            bool, const char *) override {}
+
+  // This is not used when emitting sanitizer_markup since the module is emitted
+  // ahead of time.
+  void RenderModuleLocation(InternalScopedString *, const char *, uptr,
+                            ModuleArch, const char *) override {}
+
+ protected:
+  ~FuchsiaStackTracePrinter() {}
+};
+
+StackTracePrinter *StackTracePrinter::GetOrInit() {
+  static StackTracePrinter *stacktrace_printer;
+  static StaticSpinMutex stacktrace_printer_init_mu;
+
+  SpinMutexLock l(&stacktrace_printer_init_mu);
+  if (stacktrace_printer)
+    return stacktrace_printer;
+
+  stacktrace_printer =
+      new (GetGlobalLowLevelAllocator()) FuchsiaStackTracePrinter();
+
+  CHECK(stacktrace_printer);
+  return stacktrace_printer;
+}
+
+const char *Symbolizer::Demangle(const char *name) {
+  return DemangleMarkup(name);
+}
+
+// This is used mostly for suppression matching.  Making it work
+// would enable "interceptor_via_lib" suppressions.  It's also used
+// once in UBSan to say "in module ..." in a message that also
+// includes an address in the module, so post-processing can already
+// pretty-print that so as to indicate the module.
+bool Symbolizer::GetModuleNameAndOffsetForPC(uptr pc, const char **module_name,
+                                             uptr *module_address) {
+  return false;
+}
+
+// This is mainly used by hwasan for online symbolization. This isn't needed
+// since hwasan can always ust dump stack frames for offline symbolization.
+bool Symbolizer::SymbolizeFrame(uptr addr, FrameInfo *info) { return false; }
+
+SymbolizedStack *Symbolizer::SymbolizePC(uptr addr) {
+  SymbolizedStack *s = SymbolizedStack::New(addr);
+  SymbolizePCMarkup(addr, s);
+  return s;
+}
+
+bool Symbolizer::SymbolizeData(uptr addr, DataInfo *info) {
+  return SymbolizeDataMarkup(addr, info);
+}
+
+Symbolizer *Symbolizer::PlatformInit() {
+  return new (symbolizer_allocator_) Symbolizer({});
+}
+
+void Symbolizer::LateInitialize() { Symbolizer::GetOrInit(); }
+
+void StartReportDeadlySignal() {}
+void ReportDeadlySignal(const SignalContext &sig, u32 tid,
+                        UnwindSignalStackCallbackType unwind,
+                        const void *unwind_context) {}
+
+#  if SANITIZER_CAN_SLOW_UNWIND
+struct UnwindTraceArg {
+  BufferedStackTrace *stack;
+  u32 max_depth;
+};
+
+_Unwind_Reason_Code Unwind_Trace(struct _Unwind_Context *ctx, void *param) {
+  UnwindTraceArg *arg = static_cast<UnwindTraceArg *>(param);
+  CHECK_LT(arg->stack->size, arg->max_depth);
+  uptr pc = _Unwind_GetIP(ctx);
+  if (pc < PAGE_SIZE)
+    return _URC_NORMAL_STOP;
+  arg->stack->trace_buffer[arg->stack->size++] = pc;
+  return (arg->stack->size == arg->max_depth ? _URC_NORMAL_STOP
+                                             : _URC_NO_REASON);
+}
+
+void BufferedStackTrace::UnwindSlow(uptr pc, u32 max_depth) {
+  CHECK_GE(max_depth, 2);
+  size = 0;
+  UnwindTraceArg arg = {this, Min(max_depth + 1, kStackTraceMax)};
+  _Unwind_Backtrace(Unwind_Trace, &arg);
+  CHECK_GT(size, 0);
+  // We need to pop a few frames so that pc is on top.
+  uptr to_pop = LocatePcInTrace(pc);
+  // trace_buffer[0] belongs to the current function so we always pop it,
+  // unless there is only 1 frame in the stack trace (1 frame is always better
+  // than 0!).
+  PopStackFrames(Min(to_pop, static_cast<uptr>(1)));
+  trace_buffer[0] = pc;
+}
+
+void BufferedStackTrace::UnwindSlow(uptr pc, void *context, u32 max_depth) {
+  CHECK(context);
+  CHECK_GE(max_depth, 2);
+  UNREACHABLE("signal context doesn't exist");
+}
+#  endif  // SANITIZER_CAN_SLOW_UNWIND
+
+}  // namespace __sanitizer
+
+#endif  // SANITIZER_SYMBOLIZER_FUCHSIA

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "sanitizer_allocator_internal.h"
+#include "sanitizer_common.h"
 #include "sanitizer_internal_defs.h"
 #include "sanitizer_platform.h"
 #include "sanitizer_symbolizer_internal.h"
@@ -27,7 +28,7 @@ Symbolizer *Symbolizer::GetOrInit() {
 }
 
 // See sanitizer_symbolizer_markup.cpp.
-#if !SANITIZER_SYMBOLIZER_MARKUP
+#if !SANITIZER_SYMBOLIZER_FUCHSIA
 
 const char *ExtractToken(const char *str, const char *delims, char **result) {
   uptr prefix_len = internal_strcspn(str, delims);
@@ -189,6 +190,15 @@ void Symbolizer::RefreshModules() {
   fallback_modules_.fallbackInit();
   RAW_CHECK(modules_.size() > 0);
   modules_fresh_ = true;
+}
+
+const ListOfModules &Symbolizer::GetRefreshedListOfModules() {
+  if (!modules_fresh_) {
+    RefreshModules();
+  }
+
+  CHECK(modules_fresh_);
+  return modules_;    
 }
 
 static const LoadedModule *SearchForModule(const ListOfModules &modules,
@@ -566,6 +576,6 @@ bool SymbolizerProcess::WriteToSymbolizer(const char *buffer, uptr length) {
   return true;
 }
 
-#endif  // !SANITIZER_SYMBOLIZER_MARKUP
+#endif  // !SANITIZER_SYMBOLIZER_FUCHSIA
 
 }  // namespace __sanitizer

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp
@@ -11,148 +11,169 @@
 // Implementation of offline markup symbolizer.
 //===----------------------------------------------------------------------===//
 
+#include "sanitizer_symbolizer_markup.h"
+
 #include "sanitizer_platform.h"
-#if SANITIZER_SYMBOLIZER_MARKUP
-
-#if SANITIZER_FUCHSIA
-#include "sanitizer_symbolizer_fuchsia.h"
-#  endif
-
-#  include <limits.h>
-#  include <unwind.h>
-
-#  include "sanitizer_stacktrace.h"
-#  include "sanitizer_stacktrace_printer.h"
-#  include "sanitizer_symbolizer.h"
+#include "sanitizer_symbolizer.h"
+#include "sanitizer_symbolizer_markup_constants.h"
 
 namespace __sanitizer {
 
-// This generic support for offline symbolizing is based on the
-// Fuchsia port.  We don't do any actual symbolization per se.
-// Instead, we emit text containing raw addresses and raw linkage
-// symbol names, embedded in Fuchsia's symbolization markup format.
-// Fuchsia's logging infrastructure emits enough information about
-// process memory layout that a post-processing filter can do the
-// symbolization and pretty-print the markup.  See the spec at:
-// https://fuchsia.googlesource.com/zircon/+/master/docs/symbolizer_markup.md
-
-// This is used by UBSan for type names, and by ASan for global variable names.
-// It's expected to return a static buffer that will be reused on each call.
-const char *Symbolizer::Demangle(const char *name) {
-  static char buffer[kFormatDemangleMax];
-  internal_snprintf(buffer, sizeof(buffer), kFormatDemangle, name);
-  return buffer;
-}
-
-// This is used mostly for suppression matching.  Making it work
-// would enable "interceptor_via_lib" suppressions.  It's also used
-// once in UBSan to say "in module ..." in a message that also
-// includes an address in the module, so post-processing can already
-// pretty-print that so as to indicate the module.
-bool Symbolizer::GetModuleNameAndOffsetForPC(uptr pc, const char **module_name,
-                                             uptr *module_address) {
-  return false;
-}
-
-// This is mainly used by hwasan for online symbolization. This isn't needed
-// since hwasan can always just dump stack frames for offline symbolization.
-bool Symbolizer::SymbolizeFrame(uptr addr, FrameInfo *info) { return false; }
-
-// This is used in some places for suppression checking, which we
-// don't really support for Fuchsia.  It's also used in UBSan to
-// identify a PC location to a function name, so we always fill in
-// the function member with a string containing markup around the PC
-// value.
-// TODO(mcgrathr): Under SANITIZER_GO, it's currently used by TSan
-// to render stack frames, but that should be changed to use
-// RenderStackFrame.
-SymbolizedStack *Symbolizer::SymbolizePC(uptr addr) {
-  SymbolizedStack *s = SymbolizedStack::New(addr);
+bool SymbolizePCMarkup(uptr addr, SymbolizedStack *stack) {
   char buffer[kFormatFunctionMax];
   internal_snprintf(buffer, sizeof(buffer), kFormatFunction, addr);
-  s->info.function = internal_strdup(buffer);
-  return s;
+  stack->info.function = internal_strdup(buffer);
+  return true;
 }
 
-// Always claim we succeeded, so that RenderDataInfo will be called.
-bool Symbolizer::SymbolizeData(uptr addr, DataInfo *info) {
+bool SymbolizeDataMarkup(uptr addr, DataInfo *info) {
   info->Clear();
   info->start = addr;
   return true;
 }
 
-// We ignore the format argument to __sanitizer_symbolize_global.
-void FormattedStackTracePrinter::RenderData(InternalScopedString *buffer,
-                                            const char *format,
-                                            const DataInfo *DI,
-                                            const char *strip_path_prefix) {
+const char *DemangleMarkup(const char *name) {
+  static char buffer[kFormatDemangleMax];
+  internal_snprintf(buffer, sizeof(buffer), kFormatDemangle, name);
+  return buffer;
+}
+
+
+void RenderFrameMarkup(InternalScopedString *buffer, int frame_no, uptr address) {
+  buffer->AppendF(kFormatFrame, frame_no, address);
+}
+
+
+void RenderDataMarkup(InternalScopedString *buffer, const DataInfo *DI) {
   buffer->AppendF(kFormatData, DI->start);
 }
 
-bool FormattedStackTracePrinter::RenderNeedsSymbolization(const char *format) {
+#if !SANITIZER_SYMBOLIZER_FUCHSIA
+
+bool MarkupSymbolizer::SymbolizePC(uptr addr, SymbolizedStack *stack) {
+  return SymbolizePCMarkup(addr, stack);
+}
+
+bool MarkupSymbolizer::SymbolizeData(uptr addr, DataInfo *info) {
+  return SymbolizeDataMarkup(addr, info);
+}
+
+// This is used by UBSan for type names, and by ASan for global variable names.
+// It's expected to return a static buffer that will be reused on each call.
+const char *MarkupSymbolizer::Demangle(const char *name) {
+    return DemangleMarkup(name);
+}
+
+const char *MarkupStackTracePrinter::StripFunctionName(const char *function) {
+  if (!function) {
+    return nullptr;
+  }
+
+  return function;
+}
+
+// We ignore the format argument to __sanitizer_symbolize_global.
+void MarkupStackTracePrinter::RenderData(InternalScopedString *buffer,
+                                         const char *format, const DataInfo *DI,
+                                         const char *strip_path_prefix) {
+  return RenderDataMarkup(buffer, DI);
+}
+
+bool MarkupStackTracePrinter::RenderNeedsSymbolization(const char *format) {
   return false;
 }
 
 // We don't support the stack_trace_format flag at all.
-void FormattedStackTracePrinter::RenderFrame(InternalScopedString *buffer,
-                                             const char *format, int frame_no,
-                                             uptr address,
-                                             const AddressInfo *info,
-                                             bool vs_style,
-                                             const char *strip_path_prefix) {
+void MarkupStackTracePrinter::RenderFrame(InternalScopedString *buffer,
+                                          const char *format, int frame_no,
+                                          uptr address, const AddressInfo *info,
+                                          bool vs_style,
+                                          const char *strip_path_prefix) {
   CHECK(!RenderNeedsSymbolization(format));
-  buffer->AppendF(kFormatFrame, frame_no, address);
+  RenderFrameMarkup(buffer, frame_no, address);
 }
 
-Symbolizer *Symbolizer::PlatformInit() {
-  return new (symbolizer_allocator_) Symbolizer({});
-}
-
-void Symbolizer::LateInitialize() { Symbolizer::GetOrInit(); }
-
-void StartReportDeadlySignal() {}
-void ReportDeadlySignal(const SignalContext &sig, u32 tid,
-                        UnwindSignalStackCallbackType unwind,
-                        const void *unwind_context) {}
-
-#if SANITIZER_CAN_SLOW_UNWIND
-struct UnwindTraceArg {
-  BufferedStackTrace *stack;
-  u32 max_depth;
+// Simplier view of a LoadedModule. It only holds information necessary to
+// identify unique modules.
+struct RenderedModule {
+  char *full_name;
+  u8 uuid[kModuleUUIDSize];  // BuildId
+  uptr base_address;
 };
 
-_Unwind_Reason_Code Unwind_Trace(struct _Unwind_Context *ctx, void *param) {
-  UnwindTraceArg *arg = static_cast<UnwindTraceArg *>(param);
-  CHECK_LT(arg->stack->size, arg->max_depth);
-  uptr pc = _Unwind_GetIP(ctx);
-  if (pc < PAGE_SIZE) return _URC_NORMAL_STOP;
-  arg->stack->trace_buffer[arg->stack->size++] = pc;
-  return (arg->stack->size == arg->max_depth ? _URC_NORMAL_STOP
-                                             : _URC_NO_REASON);
+bool ModulesEq(const LoadedModule *module,
+               const RenderedModule *renderedModule) {
+  return module->base_address() == renderedModule->base_address &&
+         internal_memcmp(module->uuid(), renderedModule->uuid,
+                         module->uuid_size()) == 0 &&
+         internal_strcmp(module->full_name(), renderedModule->full_name) == 0;
 }
 
-void BufferedStackTrace::UnwindSlow(uptr pc, u32 max_depth) {
-  CHECK_GE(max_depth, 2);
-  size = 0;
-  UnwindTraceArg arg = {this, Min(max_depth + 1, kStackTraceMax)};
-  _Unwind_Backtrace(Unwind_Trace, &arg);
-  CHECK_GT(size, 0);
-  // We need to pop a few frames so that pc is on top.
-  uptr to_pop = LocatePcInTrace(pc);
-  // trace_buffer[0] belongs to the current function so we always pop it,
-  // unless there is only 1 frame in the stack trace (1 frame is always better
-  // than 0!).
-  PopStackFrames(Min(to_pop, static_cast<uptr>(1)));
-  trace_buffer[0] = pc;
+bool ModuleHasBeenRendered(
+    const LoadedModule *module,
+    const InternalMmapVectorNoCtor<RenderedModule> *renderedModules) {
+  for (auto *it = renderedModules->begin(); it != renderedModules->end();
+       ++it) {
+    const auto &renderedModule = *it;
+    if (ModulesEq(module, &renderedModule)) {
+      return true;
+    }
+  }
+  return false;
 }
 
-void BufferedStackTrace::UnwindSlow(uptr pc, void *context, u32 max_depth) {
-  CHECK(context);
-  CHECK_GE(max_depth, 2);
-  UNREACHABLE("signal context doesn't exist");
+void MarkupStackTracePrinter::RenderModules(InternalScopedString *buffer,
+                                            const ListOfModules &modules) {
+  // Keeps track of the modules that have been rendered.
+  static bool initialized = false;
+  static InternalMmapVectorNoCtor<RenderedModule> renderedModules;
+  if (!initialized) {
+    renderedModules.Initialize(modules.size());
+    initialized = true;
+  }
+
+  if (!renderedModules.size()) {
+    buffer->Append("{{{reset}}}\n");
+  }
+
+  for (const auto &module : modules) {
+    if (ModuleHasBeenRendered(&module, &renderedModules)) {
+      continue;
+    }
+
+    buffer->AppendF("{{{module:%d:%s:elf:", renderedModules.size(),
+                    module.full_name());
+    for (uptr i = 0; i < module.uuid_size(); i++) {
+      buffer->AppendF("%02x", module.uuid()[i]);
+    }
+    buffer->Append("}}}\n");
+
+    for (const auto &range : module.ranges()) {
+      buffer->AppendF("{{{mmap:%p:%p:load:%d:r", range.beg,
+                      range.end - range.beg, renderedModules.size());
+      if (range.writable)
+        buffer->Append("w");
+      if (range.executable)
+        buffer->Append("x");
+
+      // module.base_address == dlpi_addr
+      // range.beg == dlpi_addr + p_vaddr
+      // relative address == p_vaddr == range.beg - module.base_address
+      buffer->AppendF(":%p}}}\n", range.beg - module.base_address());
+    }
+
+    renderedModules.push_back({});
+    RenderedModule &curModule = renderedModules.back();
+    curModule.full_name = internal_strdup(module.full_name());
+
+    // kModuleUUIDSize is the size of curModule.uuid
+    CHECK_GE(kModuleUUIDSize, module.uuid_size());
+    internal_memcpy(curModule.uuid, module.uuid(), module.uuid_size());
+
+    curModule.base_address = module.base_address();
+  }
 }
-#endif  // SANITIZER_CAN_SLOW_UNWIND
+
+#endif  // SANITIZER_SYMBOLIZER_FUCHSIA
 
 }  // namespace __sanitizer
-
-#endif  // SANITIZER_SYMBOLIZER_MARKUP

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.h
@@ -1,0 +1,99 @@
+//===-- sanitizer_symbolizer_markup.h -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is shared between various sanitizers' runtime libraries.
+//
+// Definitions of the offline markup symbolizer.
+//===----------------------------------------------------------------------===//
+
+#ifndef SANITIZER_SYMBOLIZER_MARKUP_H
+#define SANITIZER_SYMBOLIZER_MARKUP_H
+
+#include "sanitizer_common.h"
+#include "sanitizer_stacktrace_printer.h"
+#include "sanitizer_symbolizer.h"
+#include "sanitizer_symbolizer_internal.h"
+
+namespace __sanitizer {
+
+bool SymbolizePCMarkup(uptr addr, SymbolizedStack *stack);
+bool SymbolizeDataMarkup(uptr addr, DataInfo *info);
+const char *DemangleMarkup(const char *name);
+
+void RenderFrameMarkup(InternalScopedString *buffer, int frame_no,
+                       uptr address);
+
+void RenderDataMarkup(InternalScopedString *buffer, const DataInfo *DI);
+
+
+// This generic support for offline symbolizing is based on the
+// Fuchsia port.  We don't do any actual symbolization per se.
+// Instead, we emit text containing raw addresses and raw linkage
+// symbol names, embedded in Fuchsia's symbolization markup format.
+// Fuchsia's logging infrastructure emits enough information about
+// process memory layout that a post-processing filter can do the
+// symbolization and pretty-print the markup.  See the spec at:
+// https://fuchsia.googlesource.com/zircon/+/master/docs/symbolizer_markup.md
+
+class MarkupSymbolizer final : public SymbolizerTool {
+ public:
+  // This is used in some places for suppression checking, which we
+  // don't really support for Fuchsia.  It's also used in UBSan to
+  // identify a PC location to a function name, so we always fill in
+  // the function member with a string containing markup around the PC
+  // value.
+  // TODO(mcgrathr): Under SANITIZER_GO, it's currently used by TSan
+  // to render stack frames, but that should be changed to use
+  // RenderStackFrame.
+  bool SymbolizePC(uptr addr, SymbolizedStack *stack) override;
+
+  // Always claim we succeeded, so that RenderDataInfo will be called.
+  bool SymbolizeData(uptr addr, DataInfo *info) override;
+
+  // May return NULL if demangling failed.
+  // This is used by UBSan for type names, and by ASan for global variable
+  // names. It's expected to return a static buffer that will be reused on each
+  // call.
+  const char *Demangle(const char *name) override;
+};
+
+class MarkupStackTracePrinter : public StackTracePrinter {
+ public:
+  const char *StripFunctionName(const char *function) override;
+
+  void RenderFrame(InternalScopedString *buffer, const char *format,
+                   int frame_no, uptr address, const AddressInfo *info,
+                   bool vs_style, const char *strip_path_prefix = "") override;
+
+  bool RenderNeedsSymbolization(const char *format) override;
+
+  void RenderData(InternalScopedString *buffer, const char *format,
+                  const DataInfo *DI,
+                  const char *strip_path_prefix = "") override;
+
+  // Render the modules that have not been Rendered since the last call.
+  void RenderModules(InternalScopedString *buffer,
+                     const ListOfModules &modules);
+
+  // This is not used when emitting sanitizer_markup since the context for
+  // the source location is encoded in the modules and backtraces elements.
+  void RenderSourceLocation(InternalScopedString *, const char *, int, int,
+                            bool, const char *) override {}
+
+  // This is not used when emitting sanitizer_markup since the module is emitted
+  // ahead of time.
+  void RenderModuleLocation(InternalScopedString *, const char *, uptr,
+                            ModuleArch, const char *) override {}
+
+ protected:
+  ~MarkupStackTracePrinter() {}
+};
+
+}// namespace __sanitizer
+
+#endif  // SANITIZER_SYMBOLIZER_MARKUP_H

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
@@ -1,4 +1,4 @@
-//===-- sanitizer_symbolizer_fuchsia.h -----------------------------------===//
+//===-- sanitizer_symbolizer_markup_constants.h -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,8 @@
 //
 // Define Fuchsia's string formats and limits for the markup symbolizer.
 //===----------------------------------------------------------------------===//
-#ifndef SANITIZER_SYMBOLIZER_FUCHSIA_H
-#define SANITIZER_SYMBOLIZER_FUCHSIA_H
+#ifndef SANITIZER_SYMBOLIZER_MARKUP_CONSTANTS_H
+#define SANITIZER_SYMBOLIZER_MARKUP_CONSTANTS_H
 
 #include "sanitizer_internal_defs.h"
 
@@ -39,4 +39,4 @@ constexpr const char *kFormatFrame = "{{{bt:%u:%p}}}";
 
 }  // namespace __sanitizer
 
-#endif  // SANITIZER_SYMBOLIZER_FUCHSIA_H
+#endif  // SANITIZER_SYMBOLZIER_MARKUP_CONSTANTS_H

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "sanitizer_platform.h"
+#include "sanitizer_symbolizer_markup.h"
 #if SANITIZER_POSIX
 #  include <dlfcn.h>  // for dlsym()
 #  include <errno.h>
@@ -475,6 +476,13 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
     VReport(2, "Symbolizer is disabled.\n");
     return;
   }
+
+  if(common_flags()->enable_symbolizer_markup) {
+      VReport(2, "Using symbolizer markup.\n");
+      list->push_back(new(*allocator) MarkupSymbolizer());
+      return;
+  }
+
   if (IsAllocatorOutOfMemory()) {
     VReport(2, "Cannot use internal symbolizer: out of memory\n");
   } else if (SymbolizerTool *tool = InternalSymbolizer::get(allocator)) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
@@ -31,6 +31,7 @@ namespace __sanitizer {
 void ReportErrorSummary(const char *error_type, const AddressInfo &info,
                         const char *alt_tool_name) {
   if (!common_flags()->print_summary) return;
+
   InternalScopedString buff;
   buff.AppendF("%s ", error_type);
   StackTracePrinter::GetOrInit()->RenderFrame(
@@ -227,6 +228,7 @@ static void ReportDeadlySignalImpl(const SignalContext &sig, u32 tid,
   stack->Reset();
   unwind(sig, unwind_context, stack);
   stack->Print();
+  Printf("after stack print");
   MaybeDumpInstructionBytes(sig.pc);
   MaybeDumpRegisters(sig.context);
   Printf("%s can not provide additional info.\n", SanitizerToolName);

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_stacktrace_printer_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_stacktrace_printer_test.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "sanitizer_common/sanitizer_stacktrace_printer.h"
+#include "sanitizer_common/sanitizer_symbolizer_markup.h"
 
 #include "gtest/gtest.h"
 #include "interception/interception.h"
@@ -19,6 +20,11 @@ namespace __sanitizer {
 class TestFormattedStackTracePrinter final : public FormattedStackTracePrinter {
  public:
   ~TestFormattedStackTracePrinter() {}
+};
+
+class TestMarkupStackTracePrinter final : public MarkupStackTracePrinter {
+  public:
+   ~TestMarkupStackTracePrinter() {}
 };
 
 TEST(FormattedStackTracePrinter, RenderSourceLocation) {
@@ -207,6 +213,21 @@ TEST(FormattedStackTracePrinter, RenderFrame) {
   str.clear();
 
   info.Clear();
+}
+
+TEST(MarkupStackTracePrinter, RenderFrame) {
+  TestMarkupStackTracePrinter markup_printer;
+  int frame_no = 42;
+  AddressInfo info;
+  info.address = 0xaa00;
+  InternalScopedString str;
+
+  markup_printer.RenderFrame(&str, "", frame_no, info.address, &info,  false);
+  EXPECT_NE(nullptr, internal_strstr(str.data(), "{{{bt:42:"));
+  EXPECT_NE(nullptr, internal_strstr(str.data(), "aa00"));
+  EXPECT_NE(nullptr, internal_strstr(str.data(), "}}}"));
+  str.clear();
+  info.Clear();    
 }
 
 }  // namespace __sanitizer

--- a/compiler-rt/lib/xray/xray_utils.cpp
+++ b/compiler-rt/lib/xray/xray_utils.cpp
@@ -28,7 +28,7 @@
 #include <utility>
 
 #if SANITIZER_FUCHSIA
-#include "sanitizer_common/sanitizer_symbolizer_fuchsia.h"
+#include "sanitizer_common/sanitizer_symbolizer_markup_constants.h"
 
 #include <inttypes.h>
 #include <zircon/process.h>

--- a/compiler-rt/test/asan/TestCases/use-after-free-symbolizer-markup.cpp
+++ b/compiler-rt/test/asan/TestCases/use-after-free-symbolizer-markup.cpp
@@ -1,0 +1,17 @@
+// Test that verifies that asan produces valid symbolizer markup when enabled.
+// RUN: %clangxx_asan -O1 %s -o %t 
+// RUN: env ASAN_OPTIONS=enable_symbolizer_markup=1 not %run %t 2>&1 | FileCheck %s
+// REQUIRES: linux
+
+#include <stdlib.h>
+int main() {
+  char *x = (char*)malloc(10 * sizeof(char));
+  free(x);
+  return x[5];
+}
+// COM: For element syntax see: https://llvm.org/docs/SymbolizerMarkupFormat.html
+// COM: OPEN is {{{ and CLOSE is }}}
+// CHECK: [[OPEN:{{{]]reset[[CLOSE:}}}]]
+// CHECK: [[OPEN]]module:[[MOD_ID:[0-9]+]]:{{.+}}:elf:{{[0-9a-fA-F]+}}[[CLOSE]]
+// CHECK: [[OPEN]]mmap:{{0x[0-9a-fA-F]+:0x[0-9a-fA-F]+}}:load:[[MOD_ID]]:{{r[wx]{0,2}:0x[0-9a-fA-F]+}}[[CLOSE]]
+// CHECK: [[OPEN]]bt:{{[0-9]+}}:0x{{[0-9a-fA-F]+}}[[CLOSE]]

--- a/compiler-rt/test/hwasan/TestCases/use-after-free-symbolizer-markup.c
+++ b/compiler-rt/test/hwasan/TestCases/use-after-free-symbolizer-markup.c
@@ -1,0 +1,32 @@
+// Test that verifies that hwasan produces valid symbolizer markup when enabled.
+// RUN: %clang_hwasan -O0 %s -o %t
+// RUN: env HWASAN_OPTIONS=enable_symbolizer_markup=1 not %run %t 2>&1 | FileCheck %s
+// RUN: %clang_hwasan -O1 %s -o %t
+// RUN: env HWASAN_OPTIONS=enable_symbolizer_markup=1 not %run %t 2>&1 | FileCheck %s
+// RUN: %clang_hwasan -O2 %s -o %t
+// RUN: env HWASAN_OPTIONS=enable_symbolizer_markup=1 not %run %t 2>&1 | FileCheck %s
+// RUN: %clang_hwasan -O3 %s -o %t
+// RUN: env HWASAN_OPTIONS=enable_symbolizer_markup=1 not %run %t 2>&1 | FileCheck %s
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sanitizer/hwasan_interface.h>
+
+int main() {
+  __hwasan_enable_allocator_tagging();
+  char * volatile x = (char*)malloc(10);
+  free(x);
+  __hwasan_disable_allocator_tagging();
+
+  int r = 0;
+  r = x[5];
+  return r;
+}
+
+// COM: For element syntax see: https://llvm.org/docs/SymbolizerMarkupFormat.html
+// COM: OPEN is {{{ and CLOSE is }}}
+// CHECK: [[OPEN:{{{]]reset[[CLOSE:}}}]]
+// CHECK: [[OPEN]]module:[[MOD_ID:[0-9]+]]:{{.+}}:elf:{{[0-9a-fA-F]+}}[[CLOSE]]
+// CHECK: [[OPEN]]mmap:{{0x[0-9a-fA-F]+:0x[0-9a-fA-F]+}}:load:[[MOD_ID]]:{{r[wx]{0,2}:0x[0-9a-fA-F]+}}[[CLOSE]]
+// CHECK: [[OPEN]]bt:{{[0-9]+}}:0x{{[0-9a-fA-F]+}}[[CLOSE]]

--- a/llvm/utils/gn/secondary/compiler-rt/lib/sanitizer_common/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/lib/sanitizer_common/BUILD.gn
@@ -141,7 +141,7 @@ source_set("sources") {
     "sanitizer_suppressions.h",
     "sanitizer_symbolizer.cpp",
     "sanitizer_symbolizer.h",
-    "sanitizer_symbolizer_fuchsia.h",
+    "sanitizer_symbolizer_markup_constants.h",
     "sanitizer_symbolizer_internal.h",
     "sanitizer_symbolizer_libbacktrace.cpp",
     "sanitizer_symbolizer_libbacktrace.h",


### PR DESCRIPTION
This change adds initial support for sanitizer
symbolizer markup for linux. For more information
about symbolzier markup please visit
https://llvm.org/docs/SymbolizerMarkupFormat.html